### PR TITLE
Add JPA entities for core domain

### DIFF
--- a/src/main/java/gendervs/gendervs1/entity/AdminLog.java
+++ b/src/main/java/gendervs/gendervs1/entity/AdminLog.java
@@ -1,0 +1,39 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "admin_log")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "log_id")
+    private Long logId;
+
+    @ManyToOne
+    @JoinColumn(name = "admin_id")
+    private User admin;
+
+    @Column(name = "action_type", nullable = false, length = 20)
+    private String actionType;
+
+    @Column(name = "target_type", nullable = false, length = 10)
+    private String targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(name = "reason", length = 100)
+    private String reason;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/BlacklistWord.java
+++ b/src/main/java/gendervs/gendervs1/entity/BlacklistWord.java
@@ -1,0 +1,26 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "blacklist_word")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlacklistWord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "word_id")
+    private Long wordId;
+
+    @Column(name = "word", unique = true, length = 30)
+    private String word;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/Comment.java
+++ b/src/main/java/gendervs/gendervs1/entity/Comment.java
@@ -1,0 +1,60 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comment")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "depth")
+    private Integer depth = 1;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "\"like\"")
+    private Integer likeCount = 0;
+
+    @Column(name = "dislike")
+    private Integer dislikeCount = 0;
+
+    @Column(name = "status", length = 10)
+    private String status = "active";
+
+    @ManyToOne
+    @JoinColumn(name = "origin_position_id")
+    private TopicPosition originPosition;
+
+    @Column(name = "is_editable")
+    private Boolean isEditable = true;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/Post.java
+++ b/src/main/java/gendervs/gendervs1/entity/Post.java
@@ -1,0 +1,68 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "post")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long postId;
+
+    @ManyToOne
+    @JoinColumn(name = "topic_id")
+    private Topic topic;
+
+    @ManyToOne
+    @JoinColumn(name = "position_id")
+    private TopicPosition position;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "category", nullable = false, length = 20)
+    private String category;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "post_view")
+    private Integer postView = 0;
+
+    @Column(name = "\"like\"")
+    private Integer likeCount = 0;
+
+    @Column(name = "dislike")
+    private Integer dislikeCount = 0;
+
+    @Column(name = "comment")
+    private Integer commentCount = 0;
+
+    @Column(name = "influence_score")
+    private Integer influenceScore = 0;
+
+    @Column(name = "status", length = 10)
+    private String status = "active";
+
+    @Column(name = "is_editable")
+    private Boolean isEditable = true;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/PostAttachment.java
+++ b/src/main/java/gendervs/gendervs1/entity/PostAttachment.java
@@ -1,0 +1,33 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "post_attachment")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostAttachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "attachment_id")
+    private Long attachmentId;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(name = "file_url", nullable = false, length = 255)
+    private String fileUrl;
+
+    @Column(name = "file_type", nullable = false, length = 10)
+    private String fileType;
+
+    @Column(name = "uploaded_at")
+    private LocalDateTime uploadedAt;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/Report.java
+++ b/src/main/java/gendervs/gendervs1/entity/Report.java
@@ -1,0 +1,49 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "report", uniqueConstraints = @UniqueConstraint(columnNames = {"reporter_id", "target_type", "target_id"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long reportId;
+
+    @ManyToOne
+    @JoinColumn(name = "reporter_id")
+    private User reporter;
+
+    @Column(name = "target_type", nullable = false, length = 10)
+    private String targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(name = "reason_code", nullable = false, length = 20)
+    private String reasonCode;
+
+    @Column(name = "reason_text", length = 100)
+    private String reasonText;
+
+    @Column(name = "reported_at")
+    private LocalDateTime reportedAt;
+
+    @Column(name = "processed")
+    private Boolean processed = false;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "processor_id")
+    private User processor;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/TermsAgreement.java
+++ b/src/main/java/gendervs/gendervs1/entity/TermsAgreement.java
@@ -1,0 +1,30 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "terms_agreement")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TermsAgreement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "agreement_id")
+    private Long agreementId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "terms_type", nullable = false, length = 20)
+    private String termsType;
+
+    @Column(name = "agreed_at")
+    private LocalDateTime agreedAt;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/Topic.java
+++ b/src/main/java/gendervs/gendervs1/entity/Topic.java
@@ -1,0 +1,60 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "topic")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Topic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "topic_id")
+    private Long topicId;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "category", nullable = false, length = 20)
+    private String category;
+
+    @ManyToOne
+    @JoinColumn(name = "created_by")
+    private User createdBy;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "topic_view")
+    private Integer topicView = 0;
+
+    @Column(name = "\"like\"")
+    private Integer likeCount = 0;
+
+    @Column(name = "dislike")
+    private Integer dislikeCount = 0;
+
+    @Column(name = "participate")
+    private Integer participateCount = 0;
+
+    @Column(name = "post")
+    private Integer postCount = 0;
+
+    @Column(name = "status")
+    private Boolean status = true;
+
+    @Column(name = "is_editable")
+    private Boolean isEditable = true;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/TopicPosition.java
+++ b/src/main/java/gendervs/gendervs1/entity/TopicPosition.java
@@ -1,0 +1,29 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "topic_position")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TopicPosition {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "position_id")
+    private Long positionId;
+
+    @ManyToOne
+    @JoinColumn(name = "topic_id")
+    private Topic topic;
+
+    @Column(name = "position_code", nullable = false, length = 1)
+    private String positionCode;
+
+    @Column(name = "position_text", nullable = false, length = 20)
+    private String positionText;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/User.java
+++ b/src/main/java/gendervs/gendervs1/entity/User.java
@@ -1,0 +1,53 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "\"user\"")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "username", nullable = false, unique = true, length = 20)
+    private String username;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "email", nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(name = "phone_encrypted", nullable = false, unique = true, length = 255)
+    private String phoneEncrypted;
+
+    @Column(name = "phone_hash", nullable = false, unique = true, length = 64)
+    private String phoneHash;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "status")
+    private Boolean status = true;
+
+    @Column(name = "suspend_until")
+    private LocalDateTime suspendUntil;
+
+    @Column(name = "is_admin")
+    private Boolean isAdmin = false;
+
+    @Column(name = "last_login")
+    private LocalDateTime lastLogin;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/UserPosition.java
+++ b/src/main/java/gendervs/gendervs1/entity/UserPosition.java
@@ -1,0 +1,45 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_position")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPosition {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_position_id")
+    private Long userPositionId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "topic_id")
+    private Topic topic;
+
+    @ManyToOne
+    @JoinColumn(name = "position_id")
+    private TopicPosition position;
+
+    @Column(name = "selected_at")
+    private LocalDateTime selectedAt;
+
+    @Column(name = "is_current")
+    private Boolean isCurrent = true;
+
+    @Column(name = "reason", columnDefinition = "TEXT")
+    private String reason;
+
+    @ManyToOne
+    @JoinColumn(name = "reason_post_id")
+    private Post reasonPost;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/UserProfile.java
+++ b/src/main/java/gendervs/gendervs1/entity/UserProfile.java
@@ -1,0 +1,40 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_profile")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfile {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "nickname", nullable = false, unique = true, length = 30)
+    private String nickname;
+
+    @Column(name = "score")
+    private Integer score = 0;
+
+    @Column(name = "gender", nullable = false, length = 1)
+    private String gender;
+
+    @Column(name = "birth", nullable = false)
+    private LocalDate birth;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/gendervs/gendervs1/entity/Vote.java
+++ b/src/main/java/gendervs/gendervs1/entity/Vote.java
@@ -1,0 +1,36 @@
+package gendervs.gendervs1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "vote", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "target_type", "target_id"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Vote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vote_id")
+    private Long voteId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "target_type", nullable = false, length = 10)
+    private String targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(name = "vote_type", nullable = false, length = 10)
+    private String voteType;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}
+


### PR DESCRIPTION
## Summary
- define User, Topic, Post, Comment and related entities based on ERD
- include supporting entities for votes, reports and administration

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.4'] was not found in any of the following sources)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e2ab8cf0832e824ae59ca504bcf2